### PR TITLE
Use XLSX export for Google Sheets

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "aws-sdk": "^2.1.39",
     "babel": "^5.8.21",
     "babyparse": "^0.4.3",
-    "bottleneck": "^1.10.2",
     "callsite": "^1.0.0",
     "co": "^4.5.4",
     "commander": "^2.8.1",
     "csvtojson": "^0.4.1",
     "debug": "^2.2.0",
     "denodeify": "^1.2.1",
+    "entities": "^1.1.1",
     "googleapis": "^2.0.5",
     "koa": "^0.21.0",
     "koa-body": "^1.2.1",
@@ -37,7 +37,8 @@
     "moment": "^2.10.3",
     "redis": "^0.12.1",
     "request-promise": "^0.4.2",
-    "swig": "^1.4.2"
+    "swig": "^1.4.2",
+    "xlsx": "^0.8.0"
   },
   "devDependencies": {
     "bower": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "aws-sdk": "^2.1.39",
     "babel": "^5.8.21",
     "babyparse": "^0.4.3",
+    "bottleneck": "^1.10.2",
     "callsite": "^1.0.0",
     "co": "^4.5.4",
     "commander": "^2.8.1",

--- a/src/docsfile.js
+++ b/src/docsfile.js
@@ -230,7 +230,7 @@ export class DocsFile extends GuFile {
 export class SheetsFile extends GuFile {
     async fetchFileJSON(tokens) {
         var sheetODS = await rp({
-            'uri': this.metaData.exportLinks['application/x-vnd.oasis.opendocument.spreadsheet'],
+            'uri': this.metaData.exportLinks['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
             'headers': {
                 'Authorization': tokens.token_type + ' ' + tokens.access_token
             },

--- a/src/docsfile.js
+++ b/src/docsfile.js
@@ -2,25 +2,17 @@ import fs from 'fs'
 import gu from 'koa-gu'
 import rp from 'request-promise'
 import archieml from 'archieml'
+import XLSX from 'xlsx'
 import denodeify from 'denodeify'
 import google from 'googleapis'
 import { Converter } from 'csvtojson'
 import { jwtClient } from './auth.js'
 import { _ } from 'lodash'
 import Baby from 'babyparse'
-import Bottleneck from 'bottleneck'
+import sheet_to_json from './sheet_to_json'
 
 var drive = google.drive('v2')
 var key = require('../key.json');
-
-var limiter = new Bottleneck(1, 100);
-
-function docsRP(opts) {
-    return limiter.schedule(rp, opts).catch(err => {
-        gu.log.error(`Failed to get ${opts.uri}: ${err.statusCode}`);
-        throw err;
-    });
-}
 
 export class FileManager {
     constructor() {
@@ -119,9 +111,11 @@ export class FileManager {
                 for (var i = 0; i < guFiles.length; i++) {
                     if (fileId && guFiles[i].id !== fileId) continue;
                     await guFiles[i].update(tokens).catch(err => {
-                        gu.log.error('Failed to update', guFiles[i].id, guFiles[i].title)
-                        gu.log.error(err);
-                        gu.log.error(err.stack);
+                        gu.log.error('Failed to update', guFiles[i].title)
+                        gu.log.error('Error:', err);
+                        if (err && err.stack) {
+                            gu.log.error(err.stack);
+                        }
                     });
                 }
                 await FileManager.saveGuFiles(guFiles);
@@ -193,6 +187,14 @@ export class GuFile {
         } else return 'disabled';
     }
 
+    async update(tokens) {
+        gu.log.info(`Updating ${this.title}`);
+
+        this.rawBody = await this.fetchFileJSON(tokens);
+        this.domainPermissions = await this.fetchDomainPermissions();
+        return this.uploadToS3(false);
+    }
+
     uploadToS3(prod=false) {
         var uploadPath = prod ? this.pathProd : this.pathTest;
         var params = {
@@ -211,17 +213,8 @@ export class GuFile {
     }
 }
 export class DocsFile extends GuFile {
-
-    get archieJSON() { return archieml.load(this.rawBody) }
-
-    async update(tokens) {
-        this.rawBody = await this.fetchFileBody(tokens);
-        this.domainPermissions = await this.fetchDomainPermissions();
-        return this.uploadToS3(false);
-    }
-
-    fetchFileBody(tokens) {
-      return docsRP({
+    fetchFileJSON(tokens) {
+      return rp({
           uri: this.metaData.exportLinks['text/plain'],
           headers: {
               'Authorization': tokens.token_type + ' ' + tokens.access_token
@@ -229,55 +222,27 @@ export class DocsFile extends GuFile {
       });
     }
 
+    get archieJSON() { return archieml.load(this.rawBody) }
+
     get stringBody() { return JSON.stringify(this.archieJSON); }
 }
 
 export class SheetsFile extends GuFile {
-
-    async getSheetCsvGid(tokens) {
-        var embedHTML = await docsRP({
-            uri: this.metaData.embedLink,
-            headers: {
+    async fetchFileJSON(tokens) {
+        var sheetODS = await rp({
+            'uri': this.metaData.exportLinks['application/x-vnd.oasis.opendocument.spreadsheet'],
+            'headers': {
                 'Authorization': tokens.token_type + ' ' + tokens.access_token
-            }
+            },
+            'encoding': null
         });
-        var gidRegex = /gid=(\d+)/g,
-            nameRegex = /(name: ")([^"]*)/g;
-
-        var gidMatch, gids = [], nameMatch, sheetNames = [];
-        while (gidMatch = gidRegex.exec(embedHTML)) gids.push(gidMatch[1]);
-        while (nameMatch = nameRegex.exec(embedHTML)) sheetNames.push(nameMatch[2]);
-
-        this.gidNames = _.object(gids, sheetNames);
-        this.sheetNames = sheetNames;
-
-        return gids;
-    }
-
-    async getSheetAsJson(gid, tokens) {
-        var baseUrl = this.metaData.exportLinks['text/csv'],
-            json,
-            csv = await docsRP({
-                uri: `${baseUrl}&gid=${gid}`,
-                headers: {
-                    'Authorization': tokens.token_type + ' ' + tokens.access_token
-                }
-            });
-        var converter = new Converter({constructResult:true});
-        var csvToJson = denodeify(converter.fromString.bind(converter));
-
-        json = Baby.parse(csv, { header: this.gidNames[gid] !== "tableDataSheet" });
-
-        return json.data;
+        var sheets = _.mapValues(XLSX.read(sheetODS).Sheets, (sheet, sheetName) => {
+            var header = sheetName === 'tableDataSheet' ? 1 : undefined;
+            return sheet_to_json(sheet, {header});
+        })
+        fs.writeFileSync('test.json', JSON.stringify(sheets, null, 2));
+        return {sheets};
     }
 
     get stringBody() { return JSON.stringify(this.rawBody); }
-
-    async update(tokens) {
-        var sheetUrls = await this.getSheetCsvGid(tokens);
-        var sheetJsons = await Promise.all(sheetUrls.map(url => this.getSheetAsJson(url, tokens)))
-        this.rawBody = { sheets: _.zipObject(this.sheetNames, sheetJsons) };
-        this.domainPermissions = await this.fetchDomainPermissions();
-        return this.uploadToS3(false);
-    }
 }

--- a/src/docsfile.js
+++ b/src/docsfile.js
@@ -240,7 +240,6 @@ export class SheetsFile extends GuFile {
             var header = sheetName === 'tableDataSheet' ? 1 : undefined;
             return sheet_to_json(sheet, {header});
         })
-        fs.writeFileSync('test.json', JSON.stringify(sheets, null, 2));
         return {sheets};
     }
 

--- a/src/sheet_to_json.js
+++ b/src/sheet_to_json.js
@@ -1,0 +1,116 @@
+import entities from 'entities'
+
+function encode_row(row) { return "" + (row + 1); }
+function encode_col(col) { var s=""; for(++col; col; col=Math.floor((col-1)/26)) s = String.fromCharCode(((col-1)%26) + 65) + s; return s; }
+
+function safe_decode_range(range) {
+	var o = {s:{c:0,r:0},e:{c:0,r:0}};
+	var idx = 0, i = 0, cc = 0;
+	var len = range.length;
+	for(idx = 0; i < len; ++i) {
+		if((cc=range.charCodeAt(i)-64) < 1 || cc > 26) break;
+		idx = 26*idx + cc;
+	}
+	o.s.c = --idx;
+
+	for(idx = 0; i < len; ++i) {
+		if((cc=range.charCodeAt(i)-48) < 0 || cc > 9) break;
+		idx = 10*idx + cc;
+	}
+	o.s.r = --idx;
+
+	if(i === len || range.charCodeAt(++i) === 58) { o.e.c=o.s.c; o.e.r=o.s.r; return o; }
+
+	for(idx = 0; i != len; ++i) {
+		if((cc=range.charCodeAt(i)-64) < 1 || cc > 26) break;
+		idx = 26*idx + cc;
+	}
+	o.e.c = --idx;
+
+	for(idx = 0; i != len; ++i) {
+		if((cc=range.charCodeAt(i)-48) < 0 || cc > 9) break;
+		idx = 10*idx + cc;
+	}
+	o.e.r = --idx;
+	return o;
+}
+
+function safe_format_cell(cell, v) {
+	if(cell.z !== undefined) try { return (cell.w = SSF.format(cell.z, v)); } catch(e) { }
+	if(!cell.XF) return v;
+	try { return (cell.w = SSF.format(cell.XF.ifmt||0, v)); } catch(e) { return ''+v; }
+}
+
+function format_cell(cell, v) {
+	if(cell == null || cell.t == null) return "";
+	if(cell.w !== undefined) return cell.w;
+	if(v === undefined) return safe_format_cell(cell, cell.v);
+	return safe_format_cell(cell, v);
+}
+
+function decode_format_cell(cell, v) {
+    return entities.decodeXML(format_cell(cell, v));
+}
+
+function sheet_to_json(sheet, opts){
+	var val, row, range, header = 0, offset = 1, r, hdr = [], R, C, v;
+	var o = opts != null ? opts : {};
+	var raw = o.raw;
+	if(sheet == null || sheet["!ref"] == null) return [];
+	range = o.range !== undefined ? o.range : sheet["!ref"];
+	if(o.header === 1) header = 1;
+	else if(o.header === "A") header = 2;
+	else if(Array.isArray(o.header)) header = 3;
+	switch(typeof range) {
+		case 'string': r = safe_decode_range(range); break;
+		case 'number': r = safe_decode_range(sheet["!ref"]); r.s.r = range; break;
+		default: r = range;
+	}
+	if(header > 0) offset = 0;
+	var rr = encode_row(r.s.r);
+	var cols = new Array(r.e.c-r.s.c+1);
+	var out = new Array(r.e.r-r.s.r-offset+1);
+	var outi = 0;
+	for(C = r.s.c; C <= r.e.c; ++C) {
+		cols[C] = encode_col(C);
+		val = sheet[cols[C] + rr];
+		switch(header) {
+			case 1: hdr[C] = C; break;
+			case 2: hdr[C] = cols[C]; break;
+			case 3: hdr[C] = o.header[C - r.s.c]; break;
+			default:
+				hdr[C] = val === undefined ? '' : decode_format_cell(val);
+		}
+	}
+
+	for (R = r.s.r + offset; R <= r.e.r; ++R) {
+		rr = encode_row(R);
+		if(header === 1) row = [];
+		else {
+			row = {};
+			if(Object.defineProperty) Object.defineProperty(row, '__rowNum__', {value:R, enumerable:false});
+			else row.__rowNum__ = R;
+		}
+		for (C = r.s.c; C <= r.e.c; ++C) {
+			val = sheet[cols[C] + rr];
+			if(val === undefined || val.t === undefined) {
+                row[hdr[C]] = '';
+            } else {
+                v = val.v;
+                switch(val.t){
+                    case 'e': continue;
+                    case 's': break;
+                    case 'b': case 'n': break;
+                    default: throw 'unrecognized type ' + val.t;
+                }
+                console.log(val);
+                row[hdr[C]] = raw ? v : decode_format_cell(val,v);
+            }
+		}
+		out[outi++] = row;
+	}
+	out.length = outi;
+	return out;
+}
+
+export default sheet_to_json;

--- a/src/sheet_to_json.js
+++ b/src/sheet_to_json.js
@@ -1,51 +1,56 @@
+// stolen from https://github.com/SheetJS/js-xlsx/blob/53f7f6d9446ccd680c9b13992d6dcdccde49a8f6/bits/90_utils.js
+// Differences:
+//   decode entities
+//   allow empty headers/values
+
 import entities from 'entities'
 
 function encode_row(row) { return "" + (row + 1); }
 function encode_col(col) { var s=""; for(++col; col; col=Math.floor((col-1)/26)) s = String.fromCharCode(((col-1)%26) + 65) + s; return s; }
 
 function safe_decode_range(range) {
-	var o = {s:{c:0,r:0},e:{c:0,r:0}};
-	var idx = 0, i = 0, cc = 0;
-	var len = range.length;
-	for(idx = 0; i < len; ++i) {
-		if((cc=range.charCodeAt(i)-64) < 1 || cc > 26) break;
-		idx = 26*idx + cc;
-	}
-	o.s.c = --idx;
+    var o = {s:{c:0,r:0},e:{c:0,r:0}};
+    var idx = 0, i = 0, cc = 0;
+    var len = range.length;
+    for(idx = 0; i < len; ++i) {
+        if((cc=range.charCodeAt(i)-64) < 1 || cc > 26) break;
+        idx = 26*idx + cc;
+    }
+    o.s.c = --idx;
 
-	for(idx = 0; i < len; ++i) {
-		if((cc=range.charCodeAt(i)-48) < 0 || cc > 9) break;
-		idx = 10*idx + cc;
-	}
-	o.s.r = --idx;
+    for(idx = 0; i < len; ++i) {
+        if((cc=range.charCodeAt(i)-48) < 0 || cc > 9) break;
+        idx = 10*idx + cc;
+    }
+    o.s.r = --idx;
 
-	if(i === len || range.charCodeAt(++i) === 58) { o.e.c=o.s.c; o.e.r=o.s.r; return o; }
+    if(i === len || range.charCodeAt(++i) === 58) { o.e.c=o.s.c; o.e.r=o.s.r; return o; }
 
-	for(idx = 0; i != len; ++i) {
-		if((cc=range.charCodeAt(i)-64) < 1 || cc > 26) break;
-		idx = 26*idx + cc;
-	}
-	o.e.c = --idx;
+    for(idx = 0; i != len; ++i) {
+        if((cc=range.charCodeAt(i)-64) < 1 || cc > 26) break;
+        idx = 26*idx + cc;
+    }
+    o.e.c = --idx;
 
-	for(idx = 0; i != len; ++i) {
-		if((cc=range.charCodeAt(i)-48) < 0 || cc > 9) break;
-		idx = 10*idx + cc;
-	}
-	o.e.r = --idx;
-	return o;
+    for(idx = 0; i != len; ++i) {
+        if((cc=range.charCodeAt(i)-48) < 0 || cc > 9) break;
+        idx = 10*idx + cc;
+    }
+    o.e.r = --idx;
+    return o;
 }
 
 function safe_format_cell(cell, v) {
-	if(cell.z !== undefined) try { return (cell.w = SSF.format(cell.z, v)); } catch(e) { }
-	if(!cell.XF) return v;
-	try { return (cell.w = SSF.format(cell.XF.ifmt||0, v)); } catch(e) { return ''+v; }
+    if(cell.z !== undefined) try { return (cell.w = SSF.format(cell.z, v)); } catch(e) { }
+    if(!cell.XF) return v;
+    try { return (cell.w = SSF.format(cell.XF.ifmt||0, v)); } catch(e) { return ''+v; }
 }
 
 function format_cell(cell, v) {
-	if(cell == null || cell.t == null) return "";
-	if(cell.w !== undefined) return cell.w;
-	if(v === undefined) return safe_format_cell(cell, cell.v);
-	return safe_format_cell(cell, v);
+    if(cell == null || cell.t == null) return "";
+    if(cell.w !== undefined) return cell.w;
+    if(v === undefined) return safe_format_cell(cell, cell.v);
+    return safe_format_cell(cell, v);
 }
 
 function decode_format_cell(cell, v) {
@@ -53,47 +58,47 @@ function decode_format_cell(cell, v) {
 }
 
 function sheet_to_json(sheet, opts){
-	var val, row, range, header = 0, offset = 1, r, hdr = [], R, C, v;
-	var o = opts != null ? opts : {};
-	var raw = o.raw;
-	if(sheet == null || sheet["!ref"] == null) return [];
-	range = o.range !== undefined ? o.range : sheet["!ref"];
-	if(o.header === 1) header = 1;
-	else if(o.header === "A") header = 2;
-	else if(Array.isArray(o.header)) header = 3;
-	switch(typeof range) {
-		case 'string': r = safe_decode_range(range); break;
-		case 'number': r = safe_decode_range(sheet["!ref"]); r.s.r = range; break;
-		default: r = range;
-	}
-	if(header > 0) offset = 0;
-	var rr = encode_row(r.s.r);
-	var cols = new Array(r.e.c-r.s.c+1);
-	var out = new Array(r.e.r-r.s.r-offset+1);
-	var outi = 0;
-	for(C = r.s.c; C <= r.e.c; ++C) {
-		cols[C] = encode_col(C);
-		val = sheet[cols[C] + rr];
-		switch(header) {
-			case 1: hdr[C] = C; break;
-			case 2: hdr[C] = cols[C]; break;
-			case 3: hdr[C] = o.header[C - r.s.c]; break;
-			default:
-				hdr[C] = val === undefined ? '' : decode_format_cell(val);
-		}
-	}
+    var val, row, range, header = 0, offset = 1, r, hdr = [], R, C, v;
+    var o = opts != null ? opts : {};
+    var raw = o.raw;
+    if(sheet == null || sheet["!ref"] == null) return [];
+    range = o.range !== undefined ? o.range : sheet["!ref"];
+    if(o.header === 1) header = 1;
+    else if(o.header === "A") header = 2;
+    else if(Array.isArray(o.header)) header = 3;
+    switch(typeof range) {
+        case 'string': r = safe_decode_range(range); break;
+        case 'number': r = safe_decode_range(sheet["!ref"]); r.s.r = range; break;
+        default: r = range;
+    }
+    if(header > 0) offset = 0;
+    var rr = encode_row(r.s.r);
+    var cols = new Array(r.e.c-r.s.c+1);
+    var out = new Array(r.e.r-r.s.r-offset+1);
+    var outi = 0;
+    for(C = r.s.c; C <= r.e.c; ++C) {
+        cols[C] = encode_col(C);
+        val = sheet[cols[C] + rr];
+        switch(header) {
+            case 1: hdr[C] = C; break;
+            case 2: hdr[C] = cols[C]; break;
+            case 3: hdr[C] = o.header[C - r.s.c]; break;
+            default:
+                hdr[C] = decode_format_cell(val);
+        }
+    }
 
-	for (R = r.s.r + offset; R <= r.e.r; ++R) {
-		rr = encode_row(R);
-		if(header === 1) row = [];
-		else {
-			row = {};
-			if(Object.defineProperty) Object.defineProperty(row, '__rowNum__', {value:R, enumerable:false});
-			else row.__rowNum__ = R;
-		}
-		for (C = r.s.c; C <= r.e.c; ++C) {
-			val = sheet[cols[C] + rr];
-			if(val === undefined || val.t === undefined) {
+    for (R = r.s.r + offset; R <= r.e.r; ++R) {
+        rr = encode_row(R);
+        if(header === 1) row = [];
+        else {
+            row = {};
+            if(Object.defineProperty) Object.defineProperty(row, '__rowNum__', {value:R, enumerable:false});
+            else row.__rowNum__ = R;
+        }
+        for (C = r.s.c; C <= r.e.c; ++C) {
+            val = sheet[cols[C] + rr];
+            if(val === undefined || val.t === undefined) {
                 row[hdr[C]] = '';
             } else {
                 v = val.v;
@@ -103,14 +108,13 @@ function sheet_to_json(sheet, opts){
                     case 'b': case 'n': break;
                     default: throw 'unrecognized type ' + val.t;
                 }
-                console.log(val);
                 row[hdr[C]] = raw ? v : decode_format_cell(val,v);
             }
-		}
-		out[outi++] = row;
-	}
-	out.length = outi;
-	return out;
+        }
+        out[outi++] = row;
+    }
+    out.length = outi;
+    return out;
 }
 
 export default sheet_to_json;

--- a/src/sheet_to_json.js
+++ b/src/sheet_to_json.js
@@ -59,7 +59,7 @@ function decode_format_cell(cell, v) {
 }
 
 function sheet_to_json(sheet, opts){
-    var val, row, range, header = 0, offset = 1, r, hdr = [], lasti, R, C, v;
+    var val, row, range, header = 0, offset = 1, r, hdr = [], lasti = 0, R, C, v;
     var o = opts != null ? opts : {};
     var raw = o.raw;
     if(sheet == null || sheet["!ref"] == null) return [];

--- a/src/sheet_to_json.js
+++ b/src/sheet_to_json.js
@@ -2,6 +2,7 @@
 // Differences:
 //   decode entities
 //   allow empty headers/values
+//   allow empty rows, but not trailing empty rows
 
 import entities from 'entities'
 
@@ -58,7 +59,7 @@ function decode_format_cell(cell, v) {
 }
 
 function sheet_to_json(sheet, opts){
-    var val, row, range, header = 0, offset = 1, r, hdr = [], R, C, v;
+    var val, row, range, header = 0, offset = 1, r, hdr = [], lasti, R, C, v;
     var o = opts != null ? opts : {};
     var raw = o.raw;
     if(sheet == null || sheet["!ref"] == null) return [];
@@ -109,11 +110,14 @@ function sheet_to_json(sheet, opts){
                     default: throw 'unrecognized type ' + val.t;
                 }
                 row[hdr[C]] = raw ? v : decode_format_cell(val,v);
+                if (v !== undefined) {
+                    lasti = outi;
+                }
             }
         }
         out[outi++] = row;
     }
-    out.length = outi;
+    out.length = lasti + 1;
     return out;
 }
 


### PR DESCRIPTION
I've switched the export type for Sheets from `text/csv` to XLSX (known as `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` to you and me)

I've had to copy the `sheet_to_json` util from https://github.com/SheetJS/js-xlsx and modify it a bit, it didn't allow for having empty column names (doubt we need this anyway), empty values (almost certainly needed). I also added HTML entity decoding to match our current output
```
{
  "": "blah",
  "foo": "",
  "bar": "value &"
}
```
instead of:
```
{
  "undefined": "blah",
  "bar": "value &amp;"
}
```
#### Benefits
- More resilient, e.g. allows spaces in tab names
- No more rate limiting on large spreadsheets

#### Possible benefits
The world is now our oyster, spreadsheet wise

- Use the spreadsheet data type, e.g. express numbers as numbers in JSON, no more `parseInt` everywhere
- Use spreadsheet formatting, background colours etc.?