### PR TITLE
Switch to XLSX export

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["es2015"],
+    "plugins": ["syntax-async-functions", "transform-regenerator"]
+}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "moment": "^2.10.3",
     "redis": "^0.12.1",
     "request-promise": "^0.4.2",
-    "swig": "^1.4.2"
+    "swig": "^1.4.2",
+    "xlsx": "^0.8.0"
   },
   "devDependencies": {
     "bower": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "www": "./node_modules/.bin/babel-node --harmony ./src/cli.js",
+    "www": "./node_modules/.bin/babel-node ./src/cli.js",
     "dev": "./node_modules/.bin/grunt",
-    "fetch": "./node_modules/.bin/babel-node --harmony ./src/fetch.js",
+    "fetch": "./node_modules/.bin/babel-node ./src/fetch.js",
     "postinstall": "./node_modules/.bin/bower install && ./node_modules/.bin/grunt build"
   },
   "author": "",
@@ -15,7 +15,10 @@
   "dependencies": {
     "archieml": "^0.3.1",
     "aws-sdk": "^2.1.39",
-    "babel": "^5.8.21",
+    "babel-cli": "^6.9.0",
+    "babel-plugin-syntax-async-functions": "^6.8.0",
+    "babel-plugin-transform-regenerator": "^6.9.0",
+    "babel-preset-es2015": "^6.9.0",
     "babyparse": "^0.4.3",
     "callsite": "^1.0.0",
     "co": "^4.5.4",


### PR DESCRIPTION
Export spreadsheets as XLSX, convert to CSV then JSON.

Why CSV then JSON? The `xlsx.util.sheet_to_json` method does some odd things, like ignoring empty columns, which we don't want. By using CSV as an intermediate we can stick with how BabyParse does things which hopefully shouldn't break the assumptions we've made about a spreadsheet's JSON representation,