### PR TITLE
Add Exponential backoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "babel-plugin-transform-regenerator": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babyparse": "^0.4.3",
+    "bottleneck": "^1.12.0",
     "callsite": "^1.0.0",
     "co": "^4.5.4",
     "commander": "^2.8.1",

--- a/src/drive.js
+++ b/src/drive.js
@@ -19,7 +19,7 @@ const getSpreadsheet = denodeify(sheets.spreadsheets.get);
 
 async function fetchAllChanges(pageToken = undefined) {
     var options = Object.assign({auth, 'maxResults': 1000}, pageToken ? {pageToken} : {});
-    var page = await limiter(listChanges, options);
+    var page = await limiter.high(listChanges, options);
 
     var largestChangeId, items;
     if (page.nextPageToken) {
@@ -57,7 +57,7 @@ var request = (function() {
     }
 
     return function req(uri) {
-        return rlimiter(_req, uri);
+        return rlimiter.normal(_req, uri);
     };
 })();
 
@@ -67,14 +67,14 @@ export default {
     fetchAllChanges,
 
     fetchRecentChanges(startChangeId) {
-        return limiter(listChanges, {auth, startChangeId, 'maxResults': 25});
+        return limiter.high(listChanges, {auth, startChangeId, 'maxResults': 25});
     },
 
     fetchFilePermissions(fileId) {
-        return limiter(listPermissions, {auth, fileId});
+        return limiter.high(listPermissions, {auth, fileId});
     },
 
     fetchSpreadsheet(spreadsheetId) {
-        return limiter(getSpreadsheet, {auth, spreadsheetId});
+        return limiter.normal(getSpreadsheet, {auth, spreadsheetId});
     }
 }

--- a/src/fileManager.js
+++ b/src/fileManager.js
@@ -70,15 +70,17 @@ export default {
                 .filter(guFile => !!guFile); // filter any broken/unrecognized
         }
 
-        var fails = [];
-        for (var i = 0; i < guFiles.length; i++) {
-            await guFiles[i].update(prod).catch(err => {
-                gu.log.error('Failed to update', guFiles[i].id, guFiles[i].title)
-                gu.log.error(err);
-                fails.push(guFiles[i]);
-            });
-        }
+        var promises = guFiles.map(guFile => {
+            return guFile.update(prod)
+                .then(() => undefined)
+                .catch(err => {
+                    gu.log.error('Failed to update', guFile.id, guFile.title)
+                    gu.log.error(err);
+                    return guFile;
+                });
+        });
 
+        var fails = (await Promise.all(promises)).filter(f => !!f);
         if (fails.length > 0) {
             console.error('The following updates failed');
             fails.forEach(fail => console.error(`\t${fail.id} ${fail.title}`))

--- a/src/fileManager.js
+++ b/src/fileManager.js
@@ -82,8 +82,8 @@ export default {
 
         var fails = (await Promise.all(promises)).filter(f => !!f);
         if (fails.length > 0) {
-            console.error('The following updates failed');
-            fails.forEach(fail => console.error(`\t${fail.id} ${fail.title}`))
+            gu.log.error('The following updates failed');
+            fails.forEach(fail => gu.log.error(`\t${fail.id} ${fail.title}`))
         }
 
         await this.saveGuFiles(guFiles);

--- a/src/fileManager.js
+++ b/src/fileManager.js
@@ -70,12 +70,18 @@ export default {
                 .filter(guFile => !!guFile); // filter any broken/unrecognized
         }
 
+        var fails = [];
         for (var i = 0; i < guFiles.length; i++) {
             await guFiles[i].update(prod).catch(err => {
                 gu.log.error('Failed to update', guFiles[i].id, guFiles[i].title)
                 gu.log.error(err);
-                gu.log.error(err.stack);
+                fails.push(guFiles[i]);
             });
+        }
+
+        if (fails.length > 0) {
+            console.error('The following updates failed');
+            fails.forEach(fail => console.error(`\t${fail.id} ${fail.title}`))
         }
 
         await this.saveGuFiles(guFiles);

--- a/src/guFile.js
+++ b/src/guFile.js
@@ -97,13 +97,15 @@ class DocsFile extends GuFile {
 // Some magic numbers that seem to make Google happy
 const delayInitial = 500;
 const delayExp = 1.6;
+const delayCutoff = 8; // After this many sheets, just wait delayMax
+const delayMax = 20000;
 
 class SheetsFile extends GuFile {
     async fetchFileJSON() {
         var spreadsheet = await drive.fetchSpreadsheet(this.id);
         var ms = 0;
         var delays = spreadsheet.sheets.map((sheet, n) => {
-            ms += n > 8 ? 20000 : delayInitial * Math.pow(delayExp, n);
+            ms += n > delayCutoff ? delayMax : delayInitial * Math.pow(delayExp, n);
             return delay(ms, () => this.fetchSheetJSON(sheet));
         });
         try {

--- a/src/guFile.js
+++ b/src/guFile.js
@@ -5,9 +5,9 @@ import Baby from 'babyparse'
 import drive from './drive'
 import key from '../key.json'
 import { delay } from './util'
-import Bottleneck from 'bottleneck'
+import createLimiter from './limiter'
 
-var s3limiter = new Bottleneck(1, 100);
+var s3limiter = createLimiter('s3', 100);
 
 class GuFile {
     constructor({metaData, lastUploadTest = null, lastUploadProd = null, domainPermissions = 'unknown'}) {
@@ -79,7 +79,7 @@ class GuFile {
             ContentType: 'application/json',
             CacheControl: prod ? 'max-age=30' : 'max-age=5'
         }
-        var promise = s3limiter.schedule(gu.s3.putObject, params);
+        var promise = s3limiter(gu.s3.putObject, params);
         promise.then(_ =>
             this[prod ? 'lastUploadProd' : 'lastUploadTest'] = this.metaData.modifiedDate);
         promise.then(_ => gu.log.info(`Uploaded ${this.title} to ${uploadPath}`))

--- a/src/guFile.js
+++ b/src/guFile.js
@@ -7,7 +7,7 @@ import key from '../key.json'
 import { delay } from './util'
 import createLimiter from './limiter'
 
-var s3limiter = createLimiter('s3', 100);
+var s3limiter = createLimiter('s3', 50);
 
 class GuFile {
     constructor({metaData, lastUploadTest = null, lastUploadProd = null, domainPermissions = 'unknown'}) {
@@ -79,7 +79,7 @@ class GuFile {
             ContentType: 'application/json',
             CacheControl: prod ? 'max-age=30' : 'max-age=5'
         }
-        var promise = s3limiter(gu.s3.putObject, params);
+        var promise = s3limiter.normal(gu.s3.putObject, params);
         promise.then(_ =>
             this[prod ? 'lastUploadProd' : 'lastUploadTest'] = this.metaData.modifiedDate);
         promise.then(_ => gu.log.info(`Uploaded ${this.title} to ${uploadPath}`))

--- a/src/guFile.js
+++ b/src/guFile.js
@@ -90,10 +90,18 @@ class DocsFile extends GuFile {
     }
 }
 
+// Some magic numbers that seem to make Google happy
+const delayInitial = 500;
+const delayExp = 1.7;
+const delay = n => new Promise(resolve => setTimeout(resolve, delayInitial * Math.pow(delayExp, n)));
+
 class SheetsFile extends GuFile {
     async fetchFileJSON() {
         var spreadsheet = await drive.fetchSpreadsheet(this.id);
-        var sheetJSONs = await Promise.all(spreadsheet.sheets.map(sheet => this.fetchSheetJSON(sheet)));
+        var sheetJSONs = await Promise.all(spreadsheet.sheets.map((sheet, sheetNo) => {
+            return delay(sheetNo).then(() => this.fetchSheetJSON(sheet));
+        }));
+
         return {'sheets': Object.assign({}, ...sheetJSONs)};
     }
 

--- a/src/limiter.js
+++ b/src/limiter.js
@@ -1,0 +1,24 @@
+import gu from 'koa-gu'
+import Bottleneck from 'bottleneck'
+import { _ } from 'lodash'
+
+var limiters = [];
+var timeout;
+
+function logLimiters() {
+    var statuses = limiters.map(({name, limiter}) => `${name}: ${limiter.nbQueued()} queued`);
+    gu.log.info('Limiters - ' + statuses.join(', '));
+
+    var queueSizes = limiters.map(l => l.limiter.nbQueued());
+    timeout = _.sum(queueSizes) > 0 ? setTimeout(logLimiters, 20000) : undefined;
+}
+
+export default function createLimiter(name, ms) {
+    var limiter = new Bottleneck(1, ms);
+    limiters.push({name, limiter});
+
+    return (fn, ...args) => {
+        if (!timeout) timeout = setTimeout(logLimiters, 20000);
+        return limiter.schedule(fn, ...args);
+    };
+}

--- a/src/limiter.js
+++ b/src/limiter.js
@@ -17,8 +17,13 @@ export default function createLimiter(name, ms) {
     var limiter = new Bottleneck(1, ms);
     limiters.push({name, limiter});
 
-    return (fn, ...args) => {
+    function schedule(priority, fn, ...args) {
         if (!timeout) timeout = setTimeout(logLimiters, 20000);
-        return limiter.schedule(fn, ...args);
+        return limiter.schedulePriority(priority, fn, ...args);
+    }
+
+    return {
+        'normal': schedule.bind(null, 1),
+        'high': schedule.bind(null, 0)
     };
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,8 @@
+export function delay(ms, then) {
+    var interval;
+    var promise = new Promise(resolve => interval = setTimeout(resolve, ms)).then(then);
+    return {
+        cancel() { clearTimeout(interval); },
+        promise
+    };
+}


### PR DESCRIPTION
The rate limiting on the `text/csv` export endpoint is weird. It seems tied to the spreadsheet ID even though its the same base path, and even with a 5 second delay between requests it still fails after ~8 requests. 

This pull request adds an exponential rate limit per spreadsheet. The delay numbers are from random testing, but they seem to work. There won't be any noticeable change for most spreadsheets, but the big ones will take a while (10 tabs = ~100 secs). This might need looking at but there are very few spreadsheets like this.