### PR TITLE
Change s3 domain to https

### DIFF
--- a/gu.json
+++ b/gu.json
@@ -10,7 +10,7 @@
 
     "aws_profile": "visuals",
     "s3bucket": "gdn-cdn",
-    "s3domain": "http://interactive.guim.co.uk",
+    "s3domain": "https://interactive.guim.co.uk",
     "snsErrors": "arn:aws:sns:eu-west-1:868574345765:gudocs-error",
     "dbkey": "gudocs",
     "requireDomainPermissions": "guardian.co.uk",


### PR DESCRIPTION
This just caught me out. Seems like a fairly safe change to make given the way `https` works but didn't want to merge in straight away.

@desbo and @wpf500, thoughts?