### PR TITLE
Use the aws profile as defined by Janus

### DIFF
--- a/gu.json
+++ b/gu.json
@@ -8,7 +8,7 @@
 
     "logdir": "var/log",
 
-    "aws_profile": "visuals",
+    "aws_profile": "interactives",
     "s3bucket": "gdn-cdn",
     "s3domain": "https://interactive.guim.co.uk",
     "sns_errors": "arn:aws:sns:eu-west-1:868574345765:gudocs-error",


### PR DESCRIPTION
Janus doesn't list a Visuals AWS Account and from the `s3bucket` and other properties in this file, it looks like the account is `interactives` in Janus.

Looking at the history, `visuals` was added five years ago, which pre-dates Janus.