### PR TITLE
Add build script for prod deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ OR:
 - Development (auto-reload) - `npm run dev`
 - Production - `npm run www`
 
+To Deploy
+--------------
+
+Ssh into the Visuals server. Cd into the gudocs repo and git pull master. If necessary, run the build script. `./build.sh`.
+
+
 Fetching/updating docs
 ----------------------
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"  # This loads nvm
+
+nvm install
+
+npm run www


### PR DESCRIPTION
We are unsure how the node version is set in the prod build of this tool, so have added a build script to be manually run on the server in case it doesn't work. 