### PR TITLE
Revise table url

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -47,7 +47,7 @@
 					<td>
 						<a class="docs" href="{{ f.urlDocs }}">docs</a> /
 						{% if f.properties.isTable %}
-							<a class="table-embed" target="_blank" href="https://interactive.guim.co.uk/tools/tables/embed/index.html?spreadsheet={{ f.id }}">table url</a> /
+							<a class="table-embed" target="_blank" href="https://interactive.guim.co.uk/atoms/2020/08/table-tool/embed/app/main.html?spreadsheet={{ f.id }}">table url</a> /
 						{% endif %}
 						<a class="{%if f.isTestCurrent() %}current{%else%}old{%endif%}"
 							href="{{ f.urlTest }}">test</a>


### PR DESCRIPTION
## What does this change?

Revises the link for the 'table-url' button in the docs tool per user feedback.

<img width="808" alt="Screenshot 2020-12-22 at 18 36 35" src="https://user-images.githubusercontent.com/7767575/102922410-e6e46900-4485-11eb-9654-48acf9735474.png">

## How to test

The URL should be well-formed and go to the appropriate place. We'll need to confirm w/ stakeholders that it's correct.
