### PR TITLE
feat!: Remove SNS notification on error

### DIFF
--- a/dev-start-fetch.sh
+++ b/dev-start-fetch.sh
@@ -1,7 +1,6 @@
 export GU_aws_profile="composer"
 export GU_s3bucket="gudocs-dev"
 export GU_s3domain="not-used"
-export GU_sns_errors="not-used"
 export GU_dbkey="gudocs-dev"
 export GU_require_domain_permissions="dev-guardian.co.uk"
 

--- a/dev-start-ui.sh
+++ b/dev-start-ui.sh
@@ -1,7 +1,6 @@
 export GU_aws_profile="composer"
 export GU_s3bucket="gudocs-dev"
 export GU_s3domain="not-used"
-export GU_sns_errors="not-used"
 export GU_dbkey="gudocs-dev"
 export GU_require_domain_permissions="dev-guardian.co.uk"
 

--- a/gu.json
+++ b/gu.json
@@ -11,7 +11,6 @@
     "aws_profile": "interactives",
     "s3bucket": "gdn-cdn",
     "s3domain": "https://interactive.guim.co.uk",
-    "sns_errors": "arn:aws:sns:eu-west-1:868574345765:gudocs-error",
     "dbkey": "gudocs",
     "require_domain_permissions": "guardian.co.uk",
     "testFolder": "docsdata-test",

--- a/src/fileManager.js
+++ b/src/fileManager.js
@@ -2,10 +2,9 @@ import gu from 'koa-gu'
 import { _ } from 'lodash'
 import { deserialize } from './guFile'
 import drive from './drive'
-import { notify } from './util'
 
 export default {
-    
+
     async getStateDb() {
         var stateDbString = await gu.db.get(gu.config.dbkey);
         return stateDbString ? JSON.parse(stateDbString) :
@@ -86,8 +85,6 @@ export default {
         if (fails.length > 0) {
             gu.log.error('The following updates failed');
             fails.forEach(fail => gu.log.error(`\t${fail.id} ${fail.title}`));
-            var topicArn = gu.config.sns_errors
-            notify('Docs tool update errors', fails.map(fail => `${fail.id} ${fail.title}`).join('\n'), topicArn);
         }
 
         await this.saveGuFiles(guFiles);

--- a/src/guFile.js
+++ b/src/guFile.js
@@ -1,6 +1,5 @@
 import gu from 'koa-gu'
 import archieml from 'archieml'
-import { _ } from 'lodash'
 import Papa from 'papaparse'
 import drive from './drive'
 import key from '../key.json'

--- a/src/util.js
+++ b/src/util.js
@@ -1,8 +1,3 @@
-import AWS from 'aws-sdk'
-import denodeify from 'denodeify'
-import config from '../gu.json' // hack because koa-gu doesn't load config until init
-import gu from 'koa-gu'
-
 export function delay(ms, then) {
     var interval;
     var promise = new Promise(resolve => interval = setTimeout(resolve, ms)).then(then);
@@ -10,12 +5,4 @@ export function delay(ms, then) {
         cancel() { clearTimeout(interval); },
         promise
     };
-}
-
-export function notify(subject, message, topicArn) {
-    var sns = new AWS.SNS({'params': {'TopicArn': topicArn}});
-    var snsPublish = denodeify(sns.publish.bind(sns));
-    return snsPublish({'Subject': subject, 'Message': message}).catch(err => {
-        gu.log.error('Failed to send notification', err);
-    });
 }


### PR DESCRIPTION
## What does this change?
Added in #12, a notification would be sent to SNS when the doc tool failed. Today, the SNS topic has one subscriber - email for to a colleague who left a few years ago.

In this change, we remove this error notification as we're no longer reacting to the emails. The errors are still shown in the log page.

This is part of the work to understand how to establish least privilege IAM permissions.

## How can we measure success?
- Less code, in general
- Use of fewer AWS resources (the SNS topic can be removed if/when this PR is merged)
- Fewer IAM permissions required