### PR TITLE
remove ref to credentials

### DIFF
--- a/gu.json
+++ b/gu.json
@@ -8,7 +8,6 @@
 
     "logdir": "var/log",
 
-    "aws_profile": "interactives",
     "s3bucket": "gdn-cdn",
     "s3domain": "https://interactive.guim.co.uk",
     "sns_errors": "arn:aws:sns:eu-west-1:868574345765:gudocs-error",

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -6,9 +6,7 @@ import AWS from 'aws-sdk'
 
 // setup aws credentials
 gu.init({www:false});
-var credentials = new AWS.SharedIniFileCredentials(gu.config.aws_profile);
 AWS.config.region = 'eu-west-1';
-AWS.config.credentials = credentials;
 
 program
   .option('-a, --all', 'fetch all changes', false)


### PR DESCRIPTION
This removes a reference to a config file which was telling the tool to look for locally stored static credentials. Altho this does not stop the service from using the static credentials, it does eliminate this bit of code as being the bit that was telling it to (removing this code does not affect how the tool works).  The work goes on to figure out where the project is finding its credentials. This is so that we can remove the need for static credentials on the ec2 instance where the tool is running. 



## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
