### PR TITLE
Fix bug in retry code

### DIFF
--- a/src/drive.js
+++ b/src/drive.js
@@ -49,7 +49,7 @@ var request = (function() {
             if (err.statusCode === 401 && maxRetries > 0) {
                 gu.log.info('Authorization token expired');
                 token = undefined;
-                await req(uri, maxRetries - 1);
+                return await req(uri, maxRetries - 1);
             }
 
             throw err;

--- a/src/drive.js
+++ b/src/drive.js
@@ -39,26 +39,28 @@ var request = (function() {
     var token;
     var rlimiter = createLimiter('request', 400);
 
-    async function _req(uri) {
+    async function _req(uri, maxRetries) {
         gu.log.info('Requesting', uri);
         if (!token) token = await authorize();
 
         try {
             return await rp({uri, 'headers': {'Authorization': `${token.token_type} ${token.access_token}`}});
         } catch (err) {
-            if (err.statusCode === 401) {
+            if (err.statusCode === 401 && maxRetries > 0) {
                 gu.log.info('Authorization token expired');
                 token = undefined;
-                return await req(uri);
+                await req(uri, maxRetries - 1);
             }
 
             throw err;
         }
     }
 
-    return function req(uri) {
-        return rlimiter.normal(_req, uri);
+    function req(uri, maxRetries = 2) {
+        return rlimiter.normal(_req, uri, maxRetries);
     };
+
+    return req
 })();
 
 export default {


### PR DESCRIPTION
When the limiter code was added, a bug was introduced that causes the error `error:  ReferenceError: req is not defined` if a retry is attempted.

We can fix this by giving the limited function a name (`req`) and returning it.

Since fixing this bug would introduce unbounded retries, which might cause problems, I've also limited the number of retries to 3 attempts in total.
