### PR TITLE
Revert "Fix bug in retry code"

### DIFF
--- a/src/drive.js
+++ b/src/drive.js
@@ -39,28 +39,26 @@ var request = (function() {
     var token;
     var rlimiter = createLimiter('request', 400);
 
-    async function _req(uri, maxRetries) {
+    async function _req(uri) {
         gu.log.info('Requesting', uri);
         if (!token) token = await authorize();
 
         try {
             return await rp({uri, 'headers': {'Authorization': `${token.token_type} ${token.access_token}`}});
         } catch (err) {
-            if (err.statusCode === 401 && maxRetries > 0) {
+            if (err.statusCode === 401) {
                 gu.log.info('Authorization token expired');
                 token = undefined;
-                return await req(uri, maxRetries - 1);
+                return await req(uri);
             }
 
             throw err;
         }
     }
 
-    function req(uri, maxRetries = 2) {
-        return rlimiter.normal(_req, uri, maxRetries);
+    return function req(uri) {
+        return rlimiter.normal(_req, uri);
     };
-
-    return req
 })();
 
 export default {


### PR DESCRIPTION
Reverts guardian/gudocs#67

guardian/gudocs#67 attempts to address a legitimate problem (retries due to token expiry always fail because function `req` is not defined at the point it is called).

Unfortunately it introduces a much more serious bug. `rlimiter` only allows one in-flight request at a time, and can be thought of as a mutex. When a retry is attempt, the original request still holds the mutex. So the retry request will wait on the mutex, but the original request will never release the mutex because it is waiting on the retry request. This creates a deadlock.

Since `rlimiter` is shared, once a n auth token expiry happens, **all** subsequent attempt to publish will sit waiting on the lock, and therefore never happen. The only way to resolve this is to restart the service.