### PR TITLE
Keep dynamo db in sync with redis

### DIFF
--- a/dev-start-fetch.sh
+++ b/dev-start-fetch.sh
@@ -3,6 +3,7 @@ export GU_s3bucket="gudocs-dev"
 export GU_s3domain="not-used"
 export GU_dbkey="gudocs-dev"
 export GU_require_domain_permissions="dev-guardian.co.uk"
+export GU_legacy_key="insecure_key"
 
 npm run fetch
 


### PR DESCRIPTION
## What does this change?

Adds a `POST` to the new gudocs2 service any time that redis is updated. This, combined with a backfill should allow us to keep gudocs and gudocs2 in sync, with gudocs being responsible for uploading to S3. We can then cut over to the new service by disabling the gudocs scheduled task, and then enabling the gudocs2 scheduled task.